### PR TITLE
docs: add language selector to README files

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,5 +1,9 @@
 # Vix.cpp
 
+<p align="center">
+  <a href="README.md">English</a> | <strong>日本語</strong>
+</p>
+
 <p align="center" style="margin:0;">
   <img 
     src="https://res.cloudinary.com/dwjbed2xb/image/upload/v1762524350/vixcpp_etndhz.png" 
@@ -27,8 +31,6 @@
 # 🌍 Vix とは？
 
 **Vix** は、次世代の **オフラインファースト・ピアツーピア・超高速 C++ モダンランタイム**です。
-
-[English](README.md)
 
 目標は明確です。
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Vix.cpp
 
+<p align="center">
+  <strong>English</strong> | <a href="README.ja.md">日本語</a>
+</p>
+
 <p align="center" style="margin:0;">
   <img 
     src="https://res.cloudinary.com/dwjbed2xb/image/upload/v1762524350/vixcpp_etndhz.png" 
@@ -27,8 +31,6 @@
 # What is Vix?
 
 **Vix** is a next-generation **offline-first, peer-to-peer, ultra-fast runtime for modern C++**.
-
-[Japanese](README.ja.md)
 
 Its goal is clear:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "vix",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Summary
Add a language selector near the top of README.md for better discoverability of translations.

## Fixes #134 

## Changes
- Added centered language toggle (`English | 日本語`) at the top of README.md
- Added matching language toggle to README.ja.md for consistency
- Removed inline language links that were buried in content sections

## Preview
The selector appears as:

**README.md:** `English | 日本語`  
**README.ja.md:** `English | 日本語`

Current language is bold, alternate language is a clickable link.

## Checklist
- [x] README.md includes a clear language switch (EN / 日本語)
- [x] Link points to README.ja.md
- [x] Layout remains clean and minimal

