### PR TITLE
docs: improve REPL JSON documentation with examples and FAQ

### DIFF
--- a/docs/README_REPL.md
+++ b/docs/README_REPL.md
@@ -91,34 +91,52 @@ name
 
 The REPL supports **strict JSON** using `nlohmann::json`.
 
-### Objects
-
+### 1. Simple Objects
 ```text
 user = {"name":"Gaspard","age":10}
-user
 ```
 
-### Arrays
-
+### 2. Arrays
 ```text
-nums = [1,2,3,4]
-nums
+items = [1, 2, 3]
 ```
 
-### Nested data
-
+### 3. Nested Objects & Arrays
 ```text
 profile = {
-  "name":"Gaspard",
-  "meta":{"country":"UG","verified":true},
-  "tags":["cpp","vix","repl"]
+  "name": "Gaspard",
+  "meta": { "country": "UG", "verified": true },
+  "tags": ["cpp", "vix", "repl"]
 }
-profile
 ```
 
-> ⚠️ JSON must be **valid**  
-> ❌ `{ "name", "Gaspard" }`  
-> ✅ `{ "name": "Gaspard" }`
+### 4. Array of Objects
+```text
+users = [
+  { "id": 1, "name": "Alice" },
+  { "id": 2, "name": "Bob" }
+]
+```
+
+### 5. Mixed Types
+```text
+config = {
+  "active": true,
+  "threshold": 3.14,
+  "backup": null
+}
+```
+
+### ❓ Troubleshooting & Common Errors
+
+The JSON parser is **strict**. Here are common syntax mistakes:
+
+| Error Type | Invalid Syntax ❌ | Correct Syntax ✅ |
+| :--- | :--- | :--- |
+| **Missing Colon** | `{"name" "Gaspard"}` | `{"name": "Gaspard"}` |
+| **Comma instead of Colon** | `{"name", "Gaspard"}` | `{"name": "Gaspard"}` |
+| **Trailing Comma** | `{"a": 1,}` | `{"a": 1}` |
+| **Single Quotes** | `{'name': 'Gaspard'}` | `{"name": "Gaspard"}` |
 
 ---
 


### PR DESCRIPTION
This PR improves the Vix REPL documentation (docs/README_REPL.md) by expanding the JSON support section. It adds 5 concrete examples (Simple Objects, Arrays, Nested Data, Arrays of Objects, Mixed Types) and a troubleshooting FAQ table to address common syntax errors like missing colons or trailing commas.

Related issues N/A

Type of Change

1. Documentation update
2. Code Quality

- [ ]  Code follows the project style and conventions
- [ ]  C++20 (or newer) features are used appropriately
- [ ]  No unnecessary complexity introduced
- [ ]  No unused code, headers, or debug logs
- [ ]  Public APIs are documented where applicable

Tests

-  Existing tests pass locally
-  New tests were added for new behavior or fixes
-  Tests are located under tests/ or unittests/
-  ctest --output-on-failure passes (Note: Pure documentation change, no code logic affected)
- Performance (if applicable)

 Change has no negative performance impact
CLI / UX (if applicable)

CLI output is clear and consistent
Documentation

- [ ] Documentation was updated (README / docs)
- [ ] Examples were added or updated if relevant
- [ ] Comments explain non-obvious logic
- [ ] CMake / Build System

CMakeLists changes are minimal and scoped

Final Checks

- [ ]  I have rebased on the latest dev branch
- [ ]  Commit messages follow Conventional Commits
- [ ]  This PR is ready for review

- Additional Notes Pure documentation update to assist users with strict JSON syntax in the REPL.