### PR TITLE
ci(release): switch macOS runner to macos-15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
             vixos: linux
             arch: aarch64
 
-          - os: macos-13
+          - os: macos-15
             vixos: macos
             arch: x86_64
           - os: macos-14


### PR DESCRIPTION
Switch release workflow runner from macos-13 (retired) to macos-15.