### PR TITLE
v1.22.14: fix umbrella config + install package config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -879,11 +879,26 @@ if (VIX_ENABLE_INSTALL)
             FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h")
   endif()
 
-  if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/asio/include")
-    install(DIRECTORY third_party/asio/include/
-            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vix/third_party/asio
-            FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h")
-  endif()
+# ---- Install Asio headers exactly from the selected source ----
+set(_VIX_ASIO_INSTALL_SRC "")
+
+if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/asio/include/asio.hpp")
+  # vendored copy
+  set(_VIX_ASIO_INSTALL_SRC "${CMAKE_CURRENT_SOURCE_DIR}/third_party/asio/include")
+elseif (DEFINED asio_SOURCE_DIR AND EXISTS "${asio_SOURCE_DIR}/asio/include/asio.hpp")
+  # FetchContent
+  set(_VIX_ASIO_INSTALL_SRC "${asio_SOURCE_DIR}/asio/include")
+endif()
+
+if (_VIX_ASIO_INSTALL_SRC STREQUAL "")
+  message(FATAL_ERROR "Asio is required but no installable Asio headers were found.")
+endif()
+
+install(DIRECTORY "${_VIX_ASIO_INSTALL_SRC}/"
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vix/third_party/asio
+  FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h"
+)
+
 
   # Export umbrella target (modules must also export their targets into VixTargets)
   install(TARGETS vix EXPORT VixTargets)

--- a/cmake/VixConfig.cmake.in
+++ b/cmake/VixConfig.cmake.in
@@ -45,14 +45,56 @@ endif()
 # ---- MySQL (MUST be resolved BEFORE loading exported targets, if required) ----
 set(VIX_DB_WITH_MYSQL @VIX_DB_WITH_MYSQL@)
 if (VIX_DB_WITH_MYSQL)
-  find_package(MySQLCppConn CONFIG REQUIRED)
+
+  # 1) Prefer CONFIG package if available
+  find_package(MySQLCppConn CONFIG QUIET)
+
+  # 2) Fallback: pkg-config (common on Linux)
   if (NOT TARGET MySQLCppConn::MySQLCppConn)
-    message(FATAL_ERROR "Vix was built with MySQL support but MySQLCppConn::MySQLCppConn was not found.")
+    find_package(PkgConfig QUIET)
+    if (PkgConfig_FOUND)
+      pkg_check_modules(_MYSQLCPPCONN QUIET mysqlcppconn)
+      if (_MYSQLCPPCONN_FOUND)
+        add_library(MySQLCppConn::MySQLCppConn INTERFACE IMPORTED)
+        target_include_directories(MySQLCppConn::MySQLCppConn INTERFACE ${_MYSQLCPPCONN_INCLUDE_DIRS})
+        target_link_libraries(MySQLCppConn::MySQLCppConn INTERFACE ${_MYSQLCPPCONN_LINK_LIBRARIES})
+      endif()
+    endif()
+  endif()
+
+  # 3) Fallback: raw find_library/find_path
+  if (NOT TARGET MySQLCppConn::MySQLCppConn)
+    find_path(_MYSQLCPPCONN_INCLUDE_DIR mysql_connection.h
+      PATH_SUFFIXES mysqlcppconn mysql
+    )
+    find_library(_MYSQLCPPCONN_LIBRARY NAMES mysqlcppconn mysqlcppconn8)
+
+    if (_MYSQLCPPCONN_INCLUDE_DIR AND _MYSQLCPPCONN_LIBRARY)
+      add_library(MySQLCppConn::MySQLCppConn UNKNOWN IMPORTED)
+      set_target_properties(MySQLCppConn::MySQLCppConn PROPERTIES
+        IMPORTED_LOCATION "${_MYSQLCPPCONN_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${_MYSQLCPPCONN_INCLUDE_DIR}"
+      )
+    endif()
+  endif()
+
+  if (NOT TARGET MySQLCppConn::MySQLCppConn)
+    message(FATAL_ERROR
+      "Vix was built with MySQL support but MySQLCppConn could not be resolved.\n"
+      "Install libmysqlcppconn-dev (Ubuntu) or provide MySQLCppConn_DIR / CMAKE_PREFIX_PATH."
+    )
   endif()
 endif()
 
 # ---- load exported targets ----
 include("${CMAKE_CURRENT_LIST_DIR}/VixTargets.cmake")
+
+# ---- third-party exported targets (aliases) ----
+# Re-create ALIAS targets that are used in-tree, because ALIAS targets
+# are not exported by CMake.
+if (TARGET vix_thirdparty_asio AND NOT TARGET vix::thirdparty_asio)
+  add_library(vix::thirdparty_asio ALIAS vix_thirdparty_asio)
+endif()
 
 # ---- informational flags ----
 set(VIX_HAS_ORM @VIX_HAS_ORM@)


### PR DESCRIPTION
Update umbrella CMakeLists and VixConfig.cmake.in to keep the installed CMake package consistent.