### PR TITLE
v1.23.0: stabilize release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: release
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Optional tag to build/release (e.g. v1.23.0). If empty, uses the current ref."
+        required: false
+        default: ""
 
 permissions:
   contents: write
@@ -42,6 +45,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0
+
+      # If user provided a tag via workflow_dispatch, checkout that tag explicitly
+      - name: Checkout tag (manual input)
+        if: ${{ github.event.inputs.tag != '' }}
+        shell: bash
+        run: |
+          set -euxo pipefail
+          git fetch --tags --force
+          git checkout "tags/${{ github.event.inputs.tag }}"
 
       - name: Setup CMake
         uses: lukka/get-cmake@latest

--- a/README.md
+++ b/README.md
@@ -102,9 +102,10 @@ Vix.cpp is designed to remove overhead, unpredictability, and GC pauses.
 
 ```cpp
 #include <vix.hpp>
+using namespace vix;
 
 int main() {
-    vix::App app;
+    App app;
 
     app.get("/", [](Request&, Response& res){
         res.send("Hello from Vix.cpp 🚀");


### PR DESCRIPTION
Disable automatic release workflow to keep main stable. Cross-platform and Boost refactor will continue separately.