### PR TITLE
v1.34.39

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,6 @@ sudo apt install -y \
 ```bash
 brew install cmake ninja pkg-config boost openssl@3
 ```
-
-#### Windows
-- **Visual Studio 2022** (Desktop development with C++)
-- **Git**
-- **PowerShell**
-- **vcpkg** (handled automatically by the install script)
-
 ### Shell (Linux, macOS)
 
 ```bash

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,8 @@
   "name": "vix",
   "version-string": "dev",
   "dependencies": [
-    "boost",
+    "boost-system",
+    "boost-beast",
     "sqlite3",
     "openssl"
   ]


### PR DESCRIPTION
v1.34.39 reduces Windows vcpkg footprint by dropping the Boost meta-port and keeping only required deps, improving CI reliability.