### PR TITLE
v1.34.43

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -430,7 +430,7 @@ jobs:
         run: |
           set -euxo pipefail
           mkdir -p dist
-          find dist-all -type f -path "*dist-*/dist/*" -print0 | while IFS= read -r -d '' f; do
+          find dist-all -type f -path "*dist-*/*" -print0 | while IFS= read -r -d '' f; do
             base="$(basename "$f")"
             if [ -f "dist/$base" ]; then
               echo "Collision while flattening: $base" >&2

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Vix.cpp is designed to remove overhead, unpredictability, and GC pauses.
 ---
 ## Installation
 
+For detailed installation instructions, advanced options, and troubleshooting,
+visit the official installation guide:
+👉 https://vixcpp.com/install
+
 #### Linux
 **Example (Ubuntu):**
 ```bash


### PR DESCRIPTION
v1.34.43 fixes the release workflow so binaries are attached as GitHub release assets (install.sh no longer hits 404). Also updates README.