### PR TITLE
v1.34.49

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -460,7 +460,6 @@ jobs:
         shell: bash
         env:
           MINISIGN_PRIVATE_KEY_B64: ${{ secrets.MINISIGN_PRIVATE_KEY_B64 }}
-          MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
         run: |
           set -euxo pipefail
           cd dist
@@ -479,13 +478,9 @@ jobs:
           printf "%s" "$MINISIGN_PRIVATE_KEY_B64" | base64 -d > "$keyfile"
           test -s "$keyfile"
 
-          # clé minisign chiffrée -> password obligatoire
-          test -n "${MINISIGN_PASSWORD:-}" || { echo "MINISIGN_PASSWORD missing" >&2; exit 1; }
-
           for f in vix-*.tar.gz vix-*.zip; do
             [ -f "$f" ] || continue
-            # IMPORTANT: pas de -x (c'est le chemin du .minisig), et on envoie un vrai newline
-            printf '%s\n' "$MINISIGN_PASSWORD" | "$MS" -S -s "$keyfile" -m "$f"
+            "$MS" -S -s "$keyfile" -m "$f"
           done
 
           rm -f "$keyfile"

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,8 @@ create-labels.sh
 *.key
 *.minisig
 *.sha256
+# minisign private keys (CI)
+*.key
+*.key.b64
+minisign_ci.key
+minisign_ci.key.b64

--- a/minisign_ci.pub
+++ b/minisign_ci.pub
@@ -1,0 +1,2 @@
+untrusted comment: minisign public key 3BD72CED2937E88
+RWSIfpPSznK9A1gWUc8Eg2iXXQwU5d9BYuQNKGOcoujAF2stPu5rKFjQ


### PR DESCRIPTION
v1.34.49: switch minisign signing to passwordless CI key, add public key, and ignore private key artifacts.