### PR TITLE
docs: document branch protection rules and maintainer workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,24 @@ Rules:
 
 ---
 
+## Branch Protection and Maintainer Workflow
+
+The `main` branch is protected and does not allow direct pushes.
+
+All changes to `main` must be made through Pull Requests (PRs).
+
+### Maintainer Fix Workflow
+
+When applying fixes or updates, maintainers should follow this workflow:
+
+1. Create a new branch from `main`
+2. Apply the fix or change in the new branch
+3. Open a Pull Request targeting `main`
+4. Review and merge the Pull Request
+
+This ensures code quality, reviewability, and a consistent project history.
+---
+
 ## Submitting Changes
 
 1. Fork the repository


### PR DESCRIPTION
## What this PR does

This PR documents the branch protection rules and maintainer workflow for **Vix.cpp**.

It adds a new section to `CONTRIBUTING.md` explaining that:

- The `main` branch is protected and does not allow direct pushes
- All changes must go through Pull Requests
- Maintainers should follow a clear fix workflow:
  - Create a fix branch from `main`
  - Apply changes in the branch
  - Open a Pull Request
  - Review and merge the Pull Request

---

## Why this change is needed

- Makes existing branch protection rules explicit
- Reduces confusion for new contributors and maintainers
- Documents the expected workflow instead of relying on implicit GitHub rules
- Improves contributor experience and project governance clarity

---

## Scope of changes

- Documentation-only change
- No code or behavior changes
- No impact on build, runtime, or APIs

---

## Related issue

Closes #137

---

## Checklist

- [x] Documentation updated
- [x] No breaking changes
- [x] Follows project contribution guidelines
