### PR TITLE
Use vcpkg nlohmann json package on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,7 +281,6 @@ jobs:
 
           cmake -S . -B build -A x64 `
             -DVIX_ENABLE_INSTALL=OFF `
-            -DVIX_REPLY_ENABLE_INSTALL=OFF `
             -DVIX_BUILD_EXAMPLES=OFF `
             -DVIX_BUILD_TESTS=OFF `
             -DVIX_DB_USE_MYSQL=OFF `

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,9 +2,10 @@
   "name": "vix",
   "version-string": "2.1.9",
   "dependencies": [
-    "sqlite3",
+    "fmt",
+    "nlohmann-json",
     "openssl",
     "spdlog",
-    "fmt"
+    "sqlite3"
   ]
 }


### PR DESCRIPTION
Fix Windows release workflow by using the vcpkg nlohmann-json package and update p2p_http for v2.6.0.