### PR TITLE
Increase security runtime smoke timeout

### DIFF
--- a/.github/workflows/SECURITY_CI.yml
+++ b/.github/workflows/SECURITY_CI.yml
@@ -447,7 +447,7 @@ jobs:
   runtime-smoke:
     name: Runtime Smoke and CLI Checks
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 90
 
     steps:
       - name: Checkout umbrella repository


### PR DESCRIPTION
Increase the SECURITY_CI runtime smoke timeout to avoid CI failures caused by long Vix runtime and CLI checks.