### PR TITLE
Fix core benchmark consumer response type

### DIFF
--- a/.github/workflows/core-benchmarks.yml
+++ b/.github/workflows/core-benchmarks.yml
@@ -167,7 +167,7 @@ jobs:
           int main()
           {
             vix::App app;
-            app.get("/health", [](vix::Request&, vix::ResponseWrapper&) {});
+            app.get("/health", [](vix::Request&, vix::Response&) {});
             return 0;
           }
           EOF


### PR DESCRIPTION
Update the core benchmark CI consumer to use vix::Response instead of the non-public vix::ResponseWrapper type.