### PR TITLE
Update upload-artifact action to v6

### DIFF
--- a/.github/workflows/build-safety.yml
+++ b/.github/workflows/build-safety.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload benchmark report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: vix-build-benchmark-${{ github.run_id }}
           path: .vix/bench/reports/

--- a/.github/workflows/core-benchmarks.yml
+++ b/.github/workflows/core-benchmarks.yml
@@ -311,7 +311,7 @@ jobs:
 
       - name: Upload BASE, candidate, and comparison artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: core-benchmarks-${{ github.run_id }}-${{ github.run_attempt }}
           path: core-benchmark-artifacts/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,7 +309,7 @@ jobs:
 
       - name: Upload logs (Unix)
         if: always() && runner.os != 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: logs-${{ matrix.vixos }}-${{ matrix.arch }}
           path: logs/${{ matrix.vixos }}-${{ matrix.arch }}/*
@@ -431,7 +431,7 @@ jobs:
 
       - name: Upload logs (Windows)
         if: always() && runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: logs-${{ matrix.vixos }}-${{ matrix.arch }}
           path: logs/${{ matrix.vixos }}-${{ matrix.arch }}/*
@@ -735,7 +735,7 @@ jobs:
             Remove-Item -LiteralPath $smokeRoot -Recurse -Force -ErrorAction SilentlyContinue
           }
       - name: Upload dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dist-${{ matrix.vixos }}-${{ matrix.arch }}
           path: dist/*

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -469,7 +469,7 @@ jobs:
           ./consumer/build/app
 
       - name: Upload dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sdk-dist-${{ matrix.profile }}-linux-x86_64
           path: dist/*


### PR DESCRIPTION
Update artifact upload steps to use the Node 24-compatible upload-artifact action.