### PR TITLE
Disable macOS Homebrew auto upgrades in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,9 @@ jobs:
         run: |
           set -euxo pipefail
 
-          brew update
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          export HOMEBREW_NO_INSTALL_UPGRADE=1
+          export HOMEBREW_NO_INSTALL_CLEANUP=1
 
           brew install \
             cmake \


### PR DESCRIPTION
Disable Homebrew auto-update, auto-upgrade, and cleanup in release CI to avoid unrelated macOS Intel package failures.